### PR TITLE
Default currency based on current locale

### DIFF
--- a/CoinBar/Model/Preferences.swift
+++ b/CoinBar/Model/Preferences.swift
@@ -34,9 +34,14 @@ extension Preferences: Equatable {
 
 extension Preferences {
     
-    static func defaultPreferences() -> Preferences {
+    static func defaultPreferences(locale: Locale = Locale.current) -> Preferences {
         let defaultFavourites = ["bitcoin", "ethereum", "litecoin"]
-        let defaultCurrency = "USD"
+        var defaultCurrency: String {
+            guard let currencyCode = locale.currencyCode, let currency = Preferences.Currency(rawValue: currencyCode) else {
+                return Preferences.Currency.unitedStatesDollar.rawValue
+            }
+            return currency.rawValue
+        }
         let defaultChangeInterval = ChangeInterval.oneDay.rawValue
         
         return Preferences(

--- a/CoinBarTests/Model/PreferencesTests.swift
+++ b/CoinBarTests/Model/PreferencesTests.swift
@@ -6,8 +6,21 @@ final class PreferencesTests: XCTestCase {
     // MARK: - Default Prefererences
     
     func test_defaultPreferences_isCorrect() {
-        let subject = Preferences.defaultPreferences()
+        let locale = Locale(identifier: "en-US")
+        let subject = Preferences.defaultPreferences(locale: locale)
         XCTAssertEqual(subject.favouriteCoins, ["bitcoin" , "ethereum", "litecoin"])
+        XCTAssertEqual(subject.currency, "USD")
+    }
+    
+    func test_defaultPreferences_GBlocale_currencyIsSetToGBP() {
+        let locale = Locale(identifier: "gb-GB")
+        let subject = Preferences.defaultPreferences(locale: locale)
+        XCTAssertEqual(subject.currency, "GBP")
+    }
+    
+    func test_defaultPreferences_notSupportedLocale_currencyIsSetToUSD() {
+        let locale = Locale(identifier: "incorrect-Code")
+        let subject = Preferences.defaultPreferences(locale: locale)
         XCTAssertEqual(subject.currency, "USD")
     }
     

--- a/CoinBarTests/Model/PreferencesTests.swift
+++ b/CoinBarTests/Model/PreferencesTests.swift
@@ -6,20 +6,20 @@ final class PreferencesTests: XCTestCase {
     // MARK: - Default Prefererences
     
     func test_defaultPreferences_isCorrect() {
-        let locale = Locale(identifier: "en-US")
+        let locale = Locale(identifier: "en_US")
         let subject = Preferences.defaultPreferences(locale: locale)
         XCTAssertEqual(subject.favouriteCoins, ["bitcoin" , "ethereum", "litecoin"])
         XCTAssertEqual(subject.currency, "USD")
     }
     
     func test_defaultPreferences_GBlocale_currencyIsSetToGBP() {
-        let locale = Locale(identifier: "gb-GB")
+        let locale = Locale(identifier: "en_GB")
         let subject = Preferences.defaultPreferences(locale: locale)
         XCTAssertEqual(subject.currency, "GBP")
     }
     
     func test_defaultPreferences_notSupportedLocale_currencyIsSetToUSD() {
-        let locale = Locale(identifier: "incorrect-Code")
+        let locale = Locale(identifier: "incorrect_Code")
         let subject = Preferences.defaultPreferences(locale: locale)
         XCTAssertEqual(subject.currency, "USD")
     }


### PR DESCRIPTION
Addressing #13 👋
Locale is injected instead of being hardcoded. Tests created.
I also changed how default USD currency code is retrieved - instead of hardcoded string I'm using `Preferences.Currency` enum and its `rawValue`.